### PR TITLE
feat: add -t & -m flags for test/mainnet defaults

### DIFF
--- a/osmosis-installer.py
+++ b/osmosis-installer.py
@@ -4,11 +4,16 @@ import platform
 import time
 import readline
 import random
+import argparse
 from os import remove
 from sys import argv
 
 remove(argv[0])
 
+parser = argparse.ArgumentParser(description="Use default settings")
+parser.add_argument('-d', action='store_true', help='use all default settings with no input')
+
+args = parser.parse_args()
 
 class bcolors:
     HEADER = '\033[95m'
@@ -152,10 +157,14 @@ WantedBy=multi-user.target
 def cosmovisorInit ():
     print(bcolors.OKGREEN + """Do you want to use Cosmovisor to automate future upgrades?
 1) Yes, install cosmovisor and set up background service
-2) No, just set up an osmosisd background service
+2) No, just set up an osmosisd background service (recommended)
 3) Don't install cosmovisor and don't set up a background service
     """+ bcolors.ENDC)
-    useCosmovisor = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+    if args.d == True :
+        useCosmovisor = '2'
+    else:
+        useCosmovisor = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+
     if useCosmovisor == "1":
         subprocess.run(["clear"], shell=True)
         print(bcolors.OKGREEN + "Setting Up Cosmovisor..." + bcolors.ENDC)
@@ -519,7 +528,13 @@ def dataSyncSelection ():
 2) Start at block 1 and automatically upgrade at upgrade heights (replay from genesis, can also select rocksdb here)
 3) Exit now, I only wanted to install the daemon
     """+ bcolors.ENDC)
-    dataTypeAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+    if args.d == True :
+        global location; location = "Netherlands"
+        global fileName; fileName = "osmosis-1-pruned"
+        snapshotInstall()
+    else:
+        dataTypeAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+
     if dataTypeAns == "1":
         subprocess.run(["clear"], shell=True)
         mainNetType()
@@ -563,7 +578,11 @@ def pruningSettings ():
 2) Nothing: (keep everything, select this if running an archive node)
 3) Everything: (modified prune everything due to bug, keep last 10,000 states and prune at a random prime block interval)
     """+ bcolors.ENDC)
-    pruneAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+    if args.d == True :
+        pruneAns = '3'
+    else:
+        pruneAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+
     if pruneAns == "1" and networkAns == "1":
         subprocess.run(["clear"], shell=True)
         dataSyncSelection()
@@ -654,7 +673,11 @@ def setupMainnet ():
     print(bcolors.OKGREEN + "Downloading and Replacing Addressbook..." + bcolors.ENDC)
     subprocess.run(["wget -O "+osmo_home+"/config/addrbook.json https://quicksync.io/addrbook.osmosis.json"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["clear"], shell=True)
-    customPortSelection()
+
+    if args.d == True :
+        pruningSettings()
+    else:
+        customPortSelection()
 
 
 def setupTestnet ():
@@ -705,7 +728,11 @@ def clientSettings ():
 def initNodeName ():
     global nodeName
     print(bcolors.OKGREEN + "AFTER INPUTING NODE NAME, ALL PREVIOUS OSMOSIS DATA WILL BE RESET" + bcolors.ENDC)
-    nodeName= input(bcolors.OKGREEN + "Input desired node name (no quotes, cant be blank): "+ bcolors.ENDC)
+    if args.d == True :
+        nodeName = 'defaultNode'
+    else:
+        nodeName= input(bcolors.OKGREEN + "Input desired node name (no quotes, cant be blank): "+ bcolors.ENDC)
+
     if nodeName and networkAns == "1" and node == "1":
         subprocess.run(["clear"], shell=True)
         subprocess.run(["rm -r "+osmo_home], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
@@ -755,7 +782,11 @@ def installLocation ():
 1) Yes, use default location (recommended)
 2) No, specify custom location
     """+ bcolors.ENDC)
-    locationChoice = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+    if args.d == True :
+        locationChoice = '1'
+    else:
+        locationChoice = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+
     if locationChoice == "1":
         subprocess.run(["clear"], shell=True)
         osmo_home = subprocess.run(["echo $HOME/.osmosisd"], capture_output=True, shell=True, text=True).stdout.strip()
@@ -838,7 +869,11 @@ You have less than the recommended 32GB of RAM. Would you like to set up a swap 
 1) Yes, set up swap file
 2) No, do not set up swap file
             """+ bcolors.ENDC)
-            swapAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+            if args.d == True :
+                swapAns = '1'
+            else:
+                swapAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+
             if swapAns == "1":
                 swapNeeded = 32 - round(mem_gib)
                 print(bcolors.OKGREEN +"Setting up "+ str(swapNeeded)+ "GB swap file..."+ bcolors.ENDC)
@@ -904,8 +939,10 @@ def networkSelect ():
 1) Mainnet (osmosis-1)
 2) Testnet (osmo-test-4)
     """+ bcolors.ENDC)
-
-    networkAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+    if args.d == True :
+        networkAns = '1'
+    else:
+        networkAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
 
     if networkAns == '1' and node == '1':
         subprocess.run(["clear"], shell=True)
@@ -957,8 +994,10 @@ Please choose a node type:
 1) Full Node (download chain data and run locally)
 2) Client Node (setup a daemon and query a public RPC)
         """+ bcolors.ENDC)
-
-        node = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+        if args.d == True :
+            node = '1'
+        else:
+            node = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
 
         if node == '1':
             subprocess.run(["clear"], shell=True)

--- a/osmosis-installer.py
+++ b/osmosis-installer.py
@@ -11,7 +11,8 @@ from sys import argv
 remove(argv[0])
 
 parser = argparse.ArgumentParser(description="Use default settings")
-parser.add_argument('-d', action='store_true', help='use all default settings with no input')
+parser.add_argument('-m', action='store_true', help='use default settings with no input for mainnet')
+parser.add_argument('-t', action='store_true', help='use default settings with no input for mainnet')
 
 args = parser.parse_args()
 
@@ -160,7 +161,7 @@ def cosmovisorInit ():
 2) No, just set up an osmosisd background service (recommended)
 3) Don't install cosmovisor and don't set up a background service
     """+ bcolors.ENDC)
-    if args.d == True :
+    if args.m == True :
         useCosmovisor = '2'
     else:
         useCosmovisor = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
@@ -528,7 +529,7 @@ def dataSyncSelection ():
 2) Start at block 1 and automatically upgrade at upgrade heights (replay from genesis, can also select rocksdb here)
 3) Exit now, I only wanted to install the daemon
     """+ bcolors.ENDC)
-    if args.d == True :
+    if args.m == True :
         global location; location = "Netherlands"
         global fileName; fileName = "osmosis-1-pruned"
         snapshotInstall()
@@ -557,7 +558,13 @@ def dataSyncSelectionTest ():
 1) Download a snapshot from ChainLayer (recommended)
 2) Exit now, I only wanted to install the daemon
     """+ bcolors.ENDC)
-    dataTypeAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+    if args.t == True :
+        global fileName; fileName = "osmotestnet-4-pruned"
+        global location; location = "Netherlands"
+        snapshotInstall()
+    else:
+        dataTypeAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
+
     if dataTypeAns == "1":
         subprocess.run(["clear"], shell=True)
         testNetType()
@@ -578,7 +585,7 @@ def pruningSettings ():
 2) Nothing: (keep everything, select this if running an archive node)
 3) Everything: (modified prune everything due to bug, keep last 10,000 states and prune at a random prime block interval)
     """+ bcolors.ENDC)
-    if args.d == True :
+    if args.m == True :
         pruneAns = '3'
     else:
         pruneAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
@@ -674,7 +681,7 @@ def setupMainnet ():
     subprocess.run(["wget -O "+osmo_home+"/config/addrbook.json https://quicksync.io/addrbook.osmosis.json"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["clear"], shell=True)
 
-    if args.d == True :
+    if args.m == True :
         pruningSettings()
     else:
         customPortSelection()
@@ -698,7 +705,11 @@ def setupTestnet ():
     print(bcolors.OKGREEN + "Downloading and Replacing Addressbook..." + bcolors.ENDC)
     subprocess.run(["wget -O "+osmo_home+"/config/addrbook.json https://quicksync.io/addrbook.osmotestnet.json"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["clear"], shell=True)
-    customPortSelection()
+
+    if args.m == True :
+        pruningSettings()
+    else:
+        customPortSelection()
 
 
 def clientSettings ():
@@ -728,7 +739,7 @@ def clientSettings ():
 def initNodeName ():
     global nodeName
     print(bcolors.OKGREEN + "AFTER INPUTING NODE NAME, ALL PREVIOUS OSMOSIS DATA WILL BE RESET" + bcolors.ENDC)
-    if args.d == True :
+    if args.m == True :
         nodeName = 'defaultNode'
     else:
         nodeName= input(bcolors.OKGREEN + "Input desired node name (no quotes, cant be blank): "+ bcolors.ENDC)
@@ -782,7 +793,7 @@ def installLocation ():
 1) Yes, use default location (recommended)
 2) No, specify custom location
     """+ bcolors.ENDC)
-    if args.d == True :
+    if args.m == True :
         locationChoice = '1'
     else:
         locationChoice = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
@@ -869,7 +880,7 @@ You have less than the recommended 32GB of RAM. Would you like to set up a swap 
 1) Yes, set up swap file
 2) No, do not set up swap file
             """+ bcolors.ENDC)
-            if args.d == True :
+            if args.m == True :
                 swapAns = '1'
             else:
                 swapAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
@@ -939,8 +950,10 @@ def networkSelect ():
 1) Mainnet (osmosis-1)
 2) Testnet (osmo-test-4)
     """+ bcolors.ENDC)
-    if args.d == True :
+    if args.m == True and args.t != True:
         networkAns = '1'
+    elif args.t == True :
+        networkAns = '2'
     else:
         networkAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)
 
@@ -994,7 +1007,10 @@ Please choose a node type:
 1) Full Node (download chain data and run locally)
 2) Client Node (setup a daemon and query a public RPC)
         """+ bcolors.ENDC)
-        if args.d == True :
+        if args.m == True and args.t == False:
+            node = '1'
+        elif args.t == True and args.m == False :
+            args.m = True
             node = '1'
         else:
             node = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)


### PR DESCRIPTION
With these additions, if you run the script with a `-d` flag the script chooses all the default values with no user input. This will be useful for future automation. Currently default means:

- Keep recent 10,000 blocks with random prime pruning interval
- Pruned snapshot from Netherlands from ChainLayer
- background osmosis service that starts at completion (no cosmovisor)

We can change these defaults of course as we see fit. 