### PR TITLE
Parametrize Osmosis Version + update to v11.0.1

### DIFF
--- a/osmosis-installer.py
+++ b/osmosis-installer.py
@@ -12,6 +12,9 @@ from os import remove
 # self-destruct file after first call
 remove(argv[0])
 
+# Global Parameters
+OSMOSIS_VERSION="v11.0.1"
+
 class CustomHelpFormatter(argparse.HelpFormatter):
     def _format_action_invocation(self, action):
         if not action.option_strings or action.nargs == 0:
@@ -390,7 +393,7 @@ def cosmovisorInit ():
         subprocess.run(["mkdir -p "+osmo_home+"/cosmovisor/upgrades"], shell=True, env=my_env)
         subprocess.run(["mkdir -p "+osmo_home+"/cosmovisor/upgrades/v9/bin"], shell=True, env=my_env)
         os.chdir(os.path.expanduser(HOME+"/osmosis"))
-        subprocess.run(["git checkout v11.0.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
+        subprocess.run(["git checkout {v}".format(v=OSMOSIS_VERSION)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
         subprocess.run(["make build"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
         subprocess.run(["cp build/osmosisd "+osmo_home+"/cosmovisor/upgrades/v9/bin"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
         subprocess.run([". "+HOME+"/.profile"], shell=True, env=my_env)
@@ -475,7 +478,7 @@ def replayFromGenesisLevelDb ():
     subprocess.run(["make build"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["cp build/osmosisd "+osmo_home+"/cosmovisor/upgrades/v9/bin"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     print(bcolors.OKGREEN + "Preparing v11 Upgrade..." + bcolors.ENDC)
-    subprocess.run(["git checkout v11.0.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
+    subprocess.run(["git checkout {v}".format(v=OSMOSIS_VERSION)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["make build"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["cp build/osmosisd "+osmo_home+"/cosmovisor/upgrades/v11/bin"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["git checkout v3.1.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
@@ -540,7 +543,7 @@ def replayFromGenesisRocksDb ():
     subprocess.run(["BUILD_TAGS=rocksdb make build"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["cp build/osmosisd "+osmo_home+"/cosmovisor/upgrades/v9/bin"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     print(bcolors.OKGREEN + "Preparing v11 Upgrade..." + bcolors.ENDC)
-    subprocess.run(["git checkout v11.0.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
+    subprocess.run(["git checkout {v}".format(v=OSMOSIS_VERSION)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["BUILD_TAGS=rocksdb make build"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["cp build/osmosisd "+osmo_home+"/cosmovisor/upgrades/v11/bin"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
     subprocess.run(["git stash"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
@@ -1157,14 +1160,14 @@ def initSetup ():
         subprocess.run(["git stash"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         subprocess.run(["git pull"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         if networkAns == "1":
-            print(bcolors.OKGREEN + "(5/5) Installing Osmosis v11.0.0 Binary..." + bcolors.ENDC)
-            subprocess.run(["git checkout v11.0.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+            print(bcolors.OKGREEN + "(5/5) Installing Osmosis {v} Binary...".format(v=OSMOSIS_VERSION) + bcolors.ENDC)
+            subprocess.run(["git checkout {v}".format(v=OSMOSIS_VERSION)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         if networkAns == "2":
-            print(bcolors.OKGREEN + "(5/5) Installing Osmosis v11.0.0 Binary..." + bcolors.ENDC)
-            subprocess.run(["git checkout v11.0.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+            print(bcolors.OKGREEN + "(5/5) Installing Osmosis {v} Binary...".format(v=OSMOSIS_VERSION) + bcolors.ENDC)
+            subprocess.run(["git checkout {v}".format(v=OSMOSIS_VERSION)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         if networkAns == "3":
             print(bcolors.OKGREEN + "(5/5) Installing Osmosis Binary..." + bcolors.ENDC)
-            subprocess.run(["git checkout v11.0.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+            subprocess.run(["git checkout {v}".format(v=OSMOSIS_VERSION)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         my_env = os.environ.copy()
         my_env["PATH"] = "/"+HOME+"/go/bin:/"+HOME+"/go/bin:/"+HOME+"/.go/bin:" + my_env["PATH"]
         subprocess.run(["make install"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True, env=my_env)
@@ -1202,14 +1205,14 @@ def initSetup ():
         subprocess.run(["git stash"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         subprocess.run(["git pull"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         if networkAns == "1":
-            print(bcolors.OKGREEN + "(4/4) Installing Osmosis v11.0.0 Binary..." + bcolors.ENDC)
-            subprocess.run(["git checkout v11.0.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+            print(bcolors.OKGREEN + "(4/4) Installing Osmosis {v} Binary...".format(v=OSMOSIS_VERSION) + bcolors.ENDC)
+            subprocess.run(["git checkout {v}".format(v=OSMOSIS_VERSION)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         elif networkAns == "2":
-            print(bcolors.OKGREEN + "(4/4) Installing Osmosis v11.0.0 Binary..." + bcolors.ENDC)
-            subprocess.run(["git checkout v11.0.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+            print(bcolors.OKGREEN + "(4/4) Installing Osmosis {v} Binary...".format(v=OSMOSIS_VERSION) + bcolors.ENDC)
+            subprocess.run(["git checkout {v}".format(v=OSMOSIS_VERSION)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         elif networkAns == "3":
             print(bcolors.OKGREEN + "(4/4) Installing Osmosis Binary..." + bcolors.ENDC)
-            subprocess.run(["git checkout v11.0.0"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
+            subprocess.run(["git checkout {v}".format(v=OSMOSIS_VERSION)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
         my_env["PATH"] = "/"+HOME+"/go/bin:/"+HOME+"/go/bin:/"+HOME+"/.go/bin:" + my_env["PATH"]
         subprocess.run(["make install"], shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=my_env)
         if node == "3":
@@ -1361,7 +1364,7 @@ def start ():
  ╚═════╝ ╚══════╝╚═╝     ╚═╝ ╚═════╝ ╚══════╝╚═╝╚══════╝
 
 
-Welcome to the Osmosis node installer v11.0.0!
+Welcome to the Osmosis node installer {v}}!
 For more information, please visit docs.osmosis.zone
 Ensure no osmosis services are running in the background
 If running over an old osmosis installation, back up
@@ -1371,7 +1374,7 @@ Please choose a node type:
 1) Full Node (download chain data and run locally)
 2) Client Node (setup a daemon and query a public RPC)
 3) LocalOsmosis Node (setup a daemon and query a localOsmosis development RPC)
-        """+ bcolors.ENDC)
+        """.format(v=OSMOSIS_VERSION) + bcolors.ENDC)
         if args.nodeType == 'full':
             node = '1'
         elif args.nodeType == 'client':

--- a/osmosis-installer.py
+++ b/osmosis-installer.py
@@ -1362,7 +1362,7 @@ def start ():
  ╚═════╝ ╚══════╝╚═╝     ╚═╝ ╚═════╝ ╚══════╝╚═╝╚══════╝
 
 
-Welcome to the Osmosis node installer {v}}!
+Welcome to the Osmosis node installer {v}!
 For more information, please visit docs.osmosis.zone
 Ensure no osmosis services are running in the background
 If running over an old osmosis installation, back up

--- a/osmosis-installer.py
+++ b/osmosis-installer.py
@@ -6,11 +6,9 @@ import readline
 import random
 import argparse
 import sys
-from sys import argv
-from os import remove
 
 # self-destruct file after first call
-remove(argv[0])
+os.remove(sys.argv[0])
 
 # Global Parameters
 OSMOSIS_VERSION="v11.0.1"

--- a/osmosis-installer.py
+++ b/osmosis-installer.py
@@ -15,15 +15,15 @@ class NetworkVersion(str, Enum):
     MAINNET = "v11.0.1"
     TESTNET = "v11.0.1"
 
-class NetworkType(Enum):
-    MAINNET = auto()
-    TESTNET = auto()
-    LOCALOSMOSIS = auto()
+class NetworkType(str, Enum):
+    MAINNET = "1"
+    TESTNET = "2"
+    LOCALOSMOSIS = "3"
 
 class NodeType(str, Enum):
-    FULL = auto()
-    CLIENT = auto()
-    LOCALOSMOSIS = auto()
+    FULL = "1"
+    CLIENT = "2"
+    LOCALOSMOSIS = "3"
 
 class CustomHelpFormatter(argparse.HelpFormatter):
     def _format_action_invocation(self, action):
@@ -1353,10 +1353,12 @@ You have less than the recommended 32GB of RAM. Would you still like to continue
 
 def selectNetwork ():
     global networkType
-    print(bcolors.OKGREEN + """Please choose a network to join:
+    print(bcolors.OKGREEN + 
+    """
+Please choose a network to join:
 1) Mainnet (osmosis-1)
 2) Testnet (osmo-test-4)
-    """+ bcolors.ENDC)
+    """ + bcolors.ENDC)
 
     if args.network == "osmosis-1":
         networkType = networkType.MAINNET


### PR DESCRIPTION
This small PR exposes the `OSMOSIS_VERSION` as a global parameter.

This simplifies updating the `osmosis-installer` on every new minor release. 
The only thing to do is to set the `OSMOSIS_VERSION` value to the new version. 
This step can now be easily automated in our release pipeline.

This change is not enough for major releases as we would need to generalize the `useCosmovisor` step setting the correct `cosmovisor/upgrades/v*` folders.

I have also updated the installer to `v11.0.1` by changing the value 🚀

## Testing

Test the new installer:

```bash
curl https://raw.githubusercontent.com/osmosis-labs/osmosis-installer/nicco/parametrize-osmosis-version/osmosis-installer.py > installer.py && python installer.py
```



