### PR TITLE
fix snapshotLocation check

### DIFF
--- a/osmosis-installer.py
+++ b/osmosis-installer.py
@@ -748,7 +748,7 @@ def mainNetLocation ():
 2) Singapore
 3) SanFrancisco (WARNING: Location usually slow)
     """)
-    if args.snapshotLocation.lower() in location_map.values():
+    if args.snapshotLocation in location_map.values():
         nodeLocationAns = get_key(location_map, args.snapshotLocation.lower())
     else:
         nodeLocationAns = input(bcolors.OKGREEN + 'Enter Choice: '+ bcolors.ENDC)


### PR DESCRIPTION
Related to issue: https://github.com/osmosis-labs/osmosis-installer/issues/46

First entry into the location selection function tries to convert `args.snapshotLocation` to lowercase when `args.snapshotLocation` has not been assigned yet.  As a result, the script crashes due to calling `.lower()` on `NoneType`.

Remove the forced lowercase considering the options are all already in lowercase (therefore will match the `location_map` values)